### PR TITLE
Add audio channel cycling

### DIFF
--- a/orlando_edc.lxp
+++ b/orlando_edc.lxp
@@ -1,6 +1,6 @@
 {
   "version": "0.1",
-  "timestamp": 1572736866130,
+  "timestamp": 1572741171956,
   "engine": {
     "id": 1,
     "class": "heronarts.lx.LXEngine",
@@ -15,7 +15,7 @@
       "crossfader": 0.4655172396451235,
       "crossfaderBlendMode": 0,
       "speed": 1.0,
-      "focusedChannel": 4,
+      "focusedChannel": 9,
       "cueA": false,
       "cueB": false,
       "multithreaded": false,
@@ -79,7 +79,7 @@
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 0,
+        "patternIndex": 8,
         "patterns": [
           {
             "id": 717,
@@ -119,7 +119,7 @@
                     "phase": 0.0,
                     "exp": 0.0
                   },
-                  "basis": 0.7095948687790824
+                  "basis": 0.14686669024728669
                 }
               ],
               "modulations": [
@@ -418,7 +418,7 @@
                     "phase": 0.0,
                     "exp": 0.0
                   },
-                  "basis": 0.9285935382114813
+                  "basis": 0.7009410769495159
                 }
               ],
               "modulations": [
@@ -486,7 +486,7 @@
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 5,
+        "patternIndex": 11,
         "patterns": [
           {
             "id": 362,
@@ -752,7 +752,7 @@
         "parameters": {
           "label": "SPECIAL",
           "arm": false,
-          "selected": true,
+          "selected": false,
           "enabled": false,
           "cue": false,
           "fader": 0.0,
@@ -769,7 +769,7 @@
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 14,
+        "patternIndex": 5,
         "patterns": [
           {
             "id": 364,
@@ -812,10 +812,10 @@
             "parameters": {
               "label": "ShaneBow",
               "xRate": 2.0,
-              "xStart": 317.0,
-              "clockwise": false,
-              "blockWidth": 326.03411865234375,
-              "blockExp": false
+              "xStart": 112.0,
+              "clockwise": true,
+              "blockWidth": 34.10005187988281,
+              "blockExp": true
             },
             "modulation": {
               "modulators": [],
@@ -899,7 +899,7 @@
                     "phase": 0.0,
                     "exp": 0.0
                   },
-                  "basis": 0.07232589822007109
+                  "basis": 0.2104304306560433
                 }
               ],
               "modulations": [
@@ -1315,7 +1315,7 @@
           "label": "RBW",
           "arm": false,
           "selected": false,
-          "enabled": true,
+          "enabled": false,
           "cue": false,
           "fader": 1.0,
           "crossfadeGroup": 0,
@@ -1331,7 +1331,7 @@
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 2,
+        "patternIndex": 3,
         "patterns": [
           {
             "id": 2075,
@@ -1732,26 +1732,26 @@
         "class": "heronarts.lx.LXChannel",
         "modulationColor": -65464,
         "parameters": {
-          "label": "AUDIO",
+          "label": "AUDIO-1",
           "arm": false,
-          "selected": false,
-          "enabled": false,
+          "selected": true,
+          "enabled": true,
           "cue": false,
           "fader": 1.0,
           "crossfadeGroup": 0,
           "blendMode": 0,
           "midiMonitor": false,
           "midiChannel": 16,
-          "autoCycleEnabled": false,
+          "autoCycleEnabled": true,
           "autoCycleMode": 0,
           "autoCycleTimeSecs": 60.0,
-          "transitionEnabled": false,
+          "transitionEnabled": true,
           "transitionTimeSecs": 5.0,
           "transitionBlendMode": 0
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 0,
+        "patternIndex": 2,
         "patterns": [
           {
             "id": 6703,
@@ -1813,6 +1813,238 @@
             "autoCycleEnabled": true
           }
         ]
+      },
+      {
+        "id": 13638,
+        "class": "heronarts.lx.LXGroup",
+        "modulationColor": -16711870,
+        "parameters": {
+          "label": "AUDIO-MULTI",
+          "arm": false,
+          "selected": false,
+          "enabled": false,
+          "cue": false,
+          "fader": 0.013,
+          "crossfadeGroup": 0,
+          "blendMode": 0
+        },
+        "effects": [],
+        "clips": []
+      },
+      {
+        "id": 13568,
+        "class": "heronarts.lx.LXChannel",
+        "modulationColor": -16711782,
+        "parameters": {
+          "label": "AUDIO-FORM",
+          "arm": false,
+          "selected": false,
+          "enabled": true,
+          "cue": false,
+          "fader": 1.0,
+          "crossfadeGroup": 0,
+          "blendMode": 0,
+          "midiMonitor": false,
+          "midiChannel": 16,
+          "autoCycleEnabled": true,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "transitionEnabled": true,
+          "transitionTimeSecs": 5.0,
+          "transitionBlendMode": 0
+        },
+        "effects": [
+          {
+            "id": 13615,
+            "class": "heronarts.lx.effect.BlurEffect",
+            "modulationColor": -7143680,
+            "parameters": {
+              "label": "Blur",
+              "enabled": true,
+              "amount": 0.5299999937415123
+            },
+            "modulation": {
+              "modulators": [],
+              "modulations": [],
+              "triggers": []
+            }
+          }
+        ],
+        "clips": [],
+        "patternIndex": 0,
+        "patterns": [
+          {
+            "id": 13613,
+            "class": "com.giantrainbow.patterns.ShaderToy",
+            "modulationColor": -16775937,
+            "parameters": {
+              "label": "ShaderToy",
+              "Fps": 43.0,
+              "Audio": true,
+              "K1": 0.0,
+              "K2": 0.0,
+              "K3": 0.0,
+              "K4": 0.0,
+              "frag": "audiobasic",
+              "tex": "tunneltex.png"
+            },
+            "modulation": {
+              "modulators": [],
+              "modulations": [],
+              "triggers": []
+            },
+            "autoCycleEnabled": true
+          }
+        ],
+        "group": 13638
+      },
+      {
+        "id": 13583,
+        "class": "heronarts.lx.LXChannel",
+        "modulationColor": -65363,
+        "parameters": {
+          "label": "AUDIO-COLOR",
+          "arm": false,
+          "selected": false,
+          "enabled": true,
+          "cue": false,
+          "fader": 1.0,
+          "crossfadeGroup": 0,
+          "blendMode": 1,
+          "midiMonitor": false,
+          "midiChannel": 16,
+          "autoCycleEnabled": true,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 30.0,
+          "transitionEnabled": true,
+          "transitionTimeSecs": 5.0,
+          "transitionBlendMode": 0
+        },
+        "effects": [],
+        "clips": [],
+        "patternIndex": 1,
+        "patterns": [
+          {
+            "id": 13624,
+            "class": "com.giantrainbow.patterns.Rainbow",
+            "modulationColor": -65302,
+            "parameters": {
+              "label": "Rainbow"
+            },
+            "modulation": {
+              "modulators": [],
+              "modulations": [],
+              "triggers": []
+            },
+            "autoCycleEnabled": true
+          },
+          {
+            "id": 13626,
+            "class": "heronarts.lx.pattern.GradientPattern",
+            "modulationColor": -16711844,
+            "parameters": {
+              "label": "Gradient",
+              "gradient": 360.0,
+              "spreadX": 1.0,
+              "spreadY": 1.0,
+              "spreadZ": 0.0,
+              "spreadR": 0.0,
+              "offsetX": 0.0,
+              "offsetY": -1.0,
+              "offsetZ": 0.0,
+              "mirror": true
+            },
+            "modulation": {
+              "modulators": [
+                {
+                  "id": 13628,
+                  "class": "heronarts.lx.modulator.VariableLFO",
+                  "modulationColor": -16711805,
+                  "parameters": {
+                    "label": "LFO",
+                    "running": true,
+                    "trigger": false,
+                    "loop": true,
+                    "tempoSync": false,
+                    "tempoMultiplier": 5,
+                    "tempoLock": true,
+                    "clockMode": 1,
+                    "periodFast": 1000.0,
+                    "periodSlow": 30695.104565307323,
+                    "wave": 0,
+                    "skew": 0.0,
+                    "shape": 0.0,
+                    "phase": 0.0,
+                    "exp": 0.0
+                  },
+                  "basis": 0.6626400647257401
+                }
+              ],
+              "modulations": [
+                {
+                  "source": {
+                    "id": 13628
+                  },
+                  "target": {
+                    "componentId": 13626,
+                    "parameterPath": "offsetY"
+                  },
+                  "id": 13629,
+                  "class": "heronarts.lx.parameter.LXCompoundModulation",
+                  "modulationColor": -16711425,
+                  "parameters": {
+                    "label": "",
+                    "enabled": true,
+                    "Polarity": 0,
+                    "Range": 1.0
+                  }
+                }
+              ],
+              "triggers": []
+            },
+            "autoCycleEnabled": true
+          },
+          {
+            "id": 13630,
+            "class": "com.giantrainbow.patterns.EpilepticWarning",
+            "modulationColor": -16755201,
+            "parameters": {
+              "label": "EpilepticWarning",
+              "Fps": 43.0,
+              "PulseRate": 1.0,
+              "PulsePeriod": 200.0
+            },
+            "modulation": {
+              "modulators": [],
+              "modulations": [],
+              "triggers": []
+            },
+            "autoCycleEnabled": true
+          },
+          {
+            "id": 13634,
+            "class": "com.giantrainbow.patterns.ShaderToy",
+            "modulationColor": -65474,
+            "parameters": {
+              "label": "ShaderToy",
+              "Fps": 43.0,
+              "Audio": true,
+              "K1": 0.4699999950826168,
+              "K2": 1.0,
+              "K3": 0.30999999307096004,
+              "K4": 0.07999999821186066,
+              "frag": "lightning3",
+              "tex": "tunneltex.png"
+            },
+            "modulation": {
+              "modulators": [],
+              "modulations": [],
+              "triggers": []
+            },
+            "autoCycleEnabled": true
+          }
+        ],
+        "group": 13638
       },
       {
         "id": 5934,
@@ -1998,22 +2230,22 @@
           "attack": 9.999999776482582,
           "release": 18.5580048226244,
           "slope": 2.2499998826533556,
-          "Band-1": 0.7189039475057855,
-          "Band-2": 0.8232857023012915,
-          "Band-3": 0.885227792502738,
-          "Band-4": 0.9422911107810563,
-          "Band-5": 0.8556615731156034,
-          "Band-6": 0.6182864670098434,
-          "Band-7": 0.526171640103098,
-          "Band-8": 0.6862609695891189,
-          "Band-9": 0.6254662127457673,
-          "Band-10": 0.7247553377052892,
-          "Band-11": 0.7057901128559794,
-          "Band-12": 0.7736709877395042,
-          "Band-13": 0.6385955863632623,
-          "Band-14": 0.4552526362607683,
-          "Band-15": 0.07450950752677032,
-          "Band-16": 0.0
+          "Band-1": 0.7885208211116176,
+          "Band-2": 0.9185997889972549,
+          "Band-3": 0.9611310851827227,
+          "Band-4": 1.0,
+          "Band-5": 0.965351807327152,
+          "Band-6": 0.8079280985357875,
+          "Band-7": 0.6537864422242428,
+          "Band-8": 0.4813009312128482,
+          "Band-9": 0.6792204513635676,
+          "Band-10": 0.6373074939761906,
+          "Band-11": 0.6754323841488452,
+          "Band-12": 0.7486557466937138,
+          "Band-13": 0.6758263629428156,
+          "Band-14": 0.6106406284821895,
+          "Band-15": 0.4675014580398015,
+          "Band-16": 0.4834219025202675
         }
       },
       "input": {
@@ -2044,7 +2276,7 @@
       "modulationColor": -65372,
       "parameters": {
         "label": "Output",
-        "enabled": true,
+        "enabled": false,
         "mode": 0,
         "fps": 0.0,
         "gamma": 0,
@@ -2053,9 +2285,9 @@
     },
     "components": {
       "oscsensor": {
-        "id": 13500,
+        "id": 14006,
         "class": "com.giantrainbow.OSCSensor",
-        "modulationColor": -16746497,
+        "modulationColor": -51968,
         "parameters": {
           "label": "oscsensor",
           "accelx": 0.0,
@@ -2068,7 +2300,7 @@
         "stdModeTime2": 300000.0,
         "stdModeTime3": 300000.0,
         "stdModeTime4": 300000.0,
-        "stdModeFadeTime": 1000.0
+        "stdModeFadeTime": 2999.999977648258
       }
     },
     "modulation": {

--- a/orlando_edc.lxp
+++ b/orlando_edc.lxp
@@ -1,6 +1,6 @@
 {
   "version": "0.1",
-  "timestamp": 1572741171956,
+  "timestamp": 1572747102790,
   "engine": {
     "id": 1,
     "class": "heronarts.lx.LXEngine",
@@ -15,7 +15,7 @@
       "crossfader": 0.4655172396451235,
       "crossfaderBlendMode": 0,
       "speed": 1.0,
-      "focusedChannel": 9,
+      "focusedChannel": 12,
       "cueA": false,
       "cueB": false,
       "multithreaded": false,
@@ -326,9 +326,9 @@
           "midiChannel": 16,
           "autoCycleEnabled": false,
           "autoCycleMode": 0,
-          "autoCycleTimeSecs": 15.0,
+          "autoCycleTimeSecs": 30.0,
           "transitionEnabled": true,
-          "transitionTimeSecs": 3.0,
+          "transitionTimeSecs": 5.0,
           "transitionBlendMode": 0
         },
         "effects": [],
@@ -1315,7 +1315,7 @@
           "label": "RBW",
           "arm": false,
           "selected": false,
-          "enabled": false,
+          "enabled": true,
           "cue": false,
           "fader": 1.0,
           "crossfadeGroup": 0,
@@ -1331,7 +1331,7 @@
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 3,
+        "patternIndex": 5,
         "patterns": [
           {
             "id": 2075,
@@ -1598,34 +1598,6 @@
               "triggers": []
             },
             "autoCycleEnabled": true
-          },
-          {
-            "id": 12808,
-            "class": "com.giantrainbow.patterns.AnimatedTextPP",
-            "modulationColor": -16718593,
-            "parameters": {
-              "label": "AnimatedTextPP",
-              "Fps": 43.0,
-              "str": "",
-              "XSpd": 1.2,
-              "clockwise": false,
-              "oneShot": false,
-              "reset": false,
-              "advP": true,
-              "font": 3,
-              "mult": true,
-              "osc": true,
-              "fontsize": 24,
-              "centr": false,
-              "fade": 1.0,
-              "which": 0
-            },
-            "modulation": {
-              "modulators": [],
-              "modulations": [],
-              "triggers": []
-            },
-            "autoCycleEnabled": true
           }
         ],
         "group": 6997
@@ -1645,10 +1617,10 @@
           "blendMode": 0,
           "midiMonitor": false,
           "midiChannel": 16,
-          "autoCycleEnabled": false,
+          "autoCycleEnabled": true,
           "autoCycleMode": 0,
           "autoCycleTimeSecs": 60.0,
-          "transitionEnabled": false,
+          "transitionEnabled": true,
           "transitionTimeSecs": 5.0,
           "transitionBlendMode": 0
         },
@@ -1734,8 +1706,8 @@
         "parameters": {
           "label": "AUDIO-1",
           "arm": false,
-          "selected": true,
-          "enabled": true,
+          "selected": false,
+          "enabled": false,
           "cue": false,
           "fader": 1.0,
           "crossfadeGroup": 0,
@@ -1751,7 +1723,7 @@
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 2,
+        "patternIndex": 0,
         "patterns": [
           {
             "id": 6703,
@@ -1824,7 +1796,7 @@
           "selected": false,
           "enabled": false,
           "cue": false,
-          "fader": 0.013,
+          "fader": 0.001999992564320509,
           "crossfadeGroup": 0,
           "blendMode": 0
         },
@@ -1905,7 +1877,7 @@
         "parameters": {
           "label": "AUDIO-COLOR",
           "arm": false,
-          "selected": false,
+          "selected": true,
           "enabled": true,
           "cue": false,
           "fader": 1.0,
@@ -1922,7 +1894,7 @@
         },
         "effects": [],
         "clips": [],
-        "patternIndex": 1,
+        "patternIndex": 5,
         "patterns": [
           {
             "id": 13624,
@@ -1977,7 +1949,7 @@
                     "phase": 0.0,
                     "exp": 0.0
                   },
-                  "basis": 0.6626400647257401
+                  "basis": 0.9522199970946266
                 }
               ],
               "modulations": [
@@ -2034,6 +2006,45 @@
               "K3": 0.30999999307096004,
               "K4": 0.07999999821186066,
               "frag": "lightning3",
+              "tex": "tunneltex.png"
+            },
+            "modulation": {
+              "modulators": [],
+              "modulations": [],
+              "triggers": []
+            },
+            "autoCycleEnabled": true
+          },
+          {
+            "id": 14376,
+            "class": "com.giantrainbow.patterns.RainbowGIF",
+            "modulationColor": -6144,
+            "parameters": {
+              "label": "RainbowGIF",
+              "Fps": 10.0,
+              "antialias": true,
+              "gif": "hexeosis_clr02"
+            },
+            "modulation": {
+              "modulators": [],
+              "modulations": [],
+              "triggers": []
+            },
+            "autoCycleEnabled": true
+          },
+          {
+            "id": 14378,
+            "class": "com.giantrainbow.patterns.ShaderToy",
+            "modulationColor": -15597824,
+            "parameters": {
+              "label": "ShaderToy",
+              "Fps": 43.0,
+              "Audio": true,
+              "K1": 0.019999999552965164,
+              "K2": 0.009999999776482582,
+              "K3": 0.0,
+              "K4": 0.0,
+              "frag": "bezier",
               "tex": "tunneltex.png"
             },
             "modulation": {
@@ -2230,22 +2241,22 @@
           "attack": 9.999999776482582,
           "release": 18.5580048226244,
           "slope": 2.2499998826533556,
-          "Band-1": 0.7885208211116176,
-          "Band-2": 0.9185997889972549,
-          "Band-3": 0.9611310851827227,
-          "Band-4": 1.0,
-          "Band-5": 0.965351807327152,
-          "Band-6": 0.8079280985357875,
-          "Band-7": 0.6537864422242428,
-          "Band-8": 0.4813009312128482,
-          "Band-9": 0.6792204513635676,
-          "Band-10": 0.6373074939761906,
-          "Band-11": 0.6754323841488452,
-          "Band-12": 0.7486557466937138,
-          "Band-13": 0.6758263629428156,
-          "Band-14": 0.6106406284821895,
-          "Band-15": 0.4675014580398015,
-          "Band-16": 0.4834219025202675
+          "Band-1": 0.5061932188172968,
+          "Band-2": 0.5974140887351254,
+          "Band-3": 0.5806703517556749,
+          "Band-4": 0.5503517779440938,
+          "Band-5": 0.6409295889278648,
+          "Band-6": 0.6773398662297556,
+          "Band-7": 0.4984076834847899,
+          "Band-8": 0.4206137607309869,
+          "Band-9": 0.5423439003008438,
+          "Band-10": 0.5735083790842579,
+          "Band-11": 0.5853561200795528,
+          "Band-12": 0.6186409214031976,
+          "Band-13": 0.37049151833622573,
+          "Band-14": 0.3397920002395949,
+          "Band-15": 0.0,
+          "Band-16": 0.0
         }
       },
       "input": {
@@ -2276,7 +2287,7 @@
       "modulationColor": -65372,
       "parameters": {
         "label": "Output",
-        "enabled": false,
+        "enabled": true,
         "mode": 0,
         "fps": 0.0,
         "gamma": 0,
@@ -2285,9 +2296,9 @@
     },
     "components": {
       "oscsensor": {
-        "id": 14006,
+        "id": 14374,
         "class": "com.giantrainbow.OSCSensor",
-        "modulationColor": -51968,
+        "modulationColor": -131328,
         "parameters": {
           "label": "oscsensor",
           "accelx": 0.0,
@@ -2300,6 +2311,8 @@
         "stdModeTime2": 300000.0,
         "stdModeTime3": 300000.0,
         "stdModeTime4": 300000.0,
+        "audioModeTime": 120000.0,
+        "audioModeTime2": 120000.0,
         "stdModeFadeTime": 2999.999977648258
       }
     },

--- a/src/main/java/com/giantrainbow/RainbowStudio.java
+++ b/src/main/java/com/giantrainbow/RainbowStudio.java
@@ -401,6 +401,9 @@ public class RainbowStudio extends PApplet {
     private static final String KEY_STDMODE_TIME3 = "stdModeTime3";
     private static final String KEY_STDMODE_TIME4 = "stdModeTime4";
 
+    private static final String KEY_AUDIOMODE_TIME = "audioModeTime";
+    private static final String KEY_AUDIOMODE_TIME2 = "audioModeTime2";
+
     private static final String KEY_STDMODE_FADETIME = "stdModeFadeTime";
 
     @Override
@@ -409,6 +412,8 @@ public class RainbowStudio extends PApplet {
       obj.addProperty(KEY_STDMODE_TIME2, UIModeSelector.timePerChannelP2.getValue());
       obj.addProperty(KEY_STDMODE_TIME3, UIModeSelector.timePerChannelP3.getValue());
       obj.addProperty(KEY_STDMODE_TIME4, UIModeSelector.timePerChannelP4.getValue());
+      obj.addProperty(KEY_AUDIOMODE_TIME, UIModeSelector.timePerAudioChannelP1.getValue());
+      obj.addProperty(KEY_AUDIOMODE_TIME2, UIModeSelector.timePerAudioChannelP2.getValue());
       obj.addProperty(KEY_STDMODE_FADETIME, UIModeSelector.fadeTimeP.getValue());
     }
 
@@ -426,6 +431,12 @@ public class RainbowStudio extends PApplet {
       }
       if (obj.has(KEY_STDMODE_TIME4)) {
         UIModeSelector.timePerChannelP4.setValue(obj.get(KEY_STDMODE_TIME4).getAsDouble());
+      }
+      if (obj.has(KEY_AUDIOMODE_TIME)) {
+        UIModeSelector.timePerAudioChannelP1.setValue(obj.get(KEY_AUDIOMODE_TIME).getAsDouble());
+      }
+      if (obj.has(KEY_AUDIOMODE_TIME2)) {
+        UIModeSelector.timePerAudioChannelP2.setValue(obj.get(KEY_AUDIOMODE_TIME2).getAsDouble());
       }
       if (obj.has(KEY_STDMODE_FADETIME)) {
         UIModeSelector.fadeTimeP.setValue(obj.get(KEY_STDMODE_FADETIME).getAsDouble());

--- a/src/main/java/com/giantrainbow/ui/UIModeSelector.java
+++ b/src/main/java/com/giantrainbow/ui/UIModeSelector.java
@@ -28,6 +28,7 @@ public class UIModeSelector extends UICollapsibleSection {
   public final UIButton textMode;
 
   protected LX lx;
+  protected LXStudio.UI ui;
   public BooleanParameter autoAudioModeP = new BooleanParameter("autoaudio", false);
   public BooleanParameter audioModeP = new BooleanParameter("audio", false);
   public BooleanParameter standardModeP = new BooleanParameter("standard", false);
@@ -35,13 +36,13 @@ public class UIModeSelector extends UICollapsibleSection {
   public BooleanParameter instrumentModeP = new BooleanParameter("instrument", false);
   public BooleanParameter textModeP = new BooleanParameter("text", false);
 
-  static public BoundedParameter timePerChannelP = new BoundedParameter("MultiT", 60000.0, 2000.0, 360000.0);
-  static public BoundedParameter timePerChannelP2 = new BoundedParameter("GifT", 60000.0, 2000.0, 360000.0);
-  static public BoundedParameter timePerChannelP3 = new BoundedParameter("SpecialT", 60000.0, 2000.0, 360000.0);
-  static public BoundedParameter timePerChannelP4 = new BoundedParameter("RbwT", 60000.0, 2000.0, 360000.0);
+  static public BoundedParameter timePerChannelP = new BoundedParameter("Multi", 60000.0, 2000.0, 360000.0);
+  static public BoundedParameter timePerChannelP2 = new BoundedParameter("Gif", 60000.0, 2000.0, 360000.0);
+  static public BoundedParameter timePerChannelP3 = new BoundedParameter("Special", 60000.0, 2000.0, 360000.0);
+  static public BoundedParameter timePerChannelP4 = new BoundedParameter("Rbw", 60000.0, 2000.0, 360000.0);
 
-  static public BoundedParameter timePerAudioChannelP1 = new BoundedParameter("Aud-1T", 60000.0, 2000.0, 360000.0);
-  static public BoundedParameter timePerAudioChannelP2 = new BoundedParameter("Aud-MultiT", 60000.0, 2000.0, 360000.0);
+  static public BoundedParameter timePerAudioChannelP1 = new BoundedParameter("Aud-1", 60000.0, 2000.0, 360000.0);
+  static public BoundedParameter timePerAudioChannelP2 = new BoundedParameter("Aud-Multi", 60000.0, 2000.0, 360000.0);
 
   static public BoundedParameter fadeTimeP = new BoundedParameter("FadeT", 1000.0, 0.000, 10000.0);
   public final UIKnob timePerChannel;
@@ -70,6 +71,7 @@ public class UIModeSelector extends UICollapsibleSection {
     setLayout(UI2dContainer.Layout.VERTICAL);
     setChildMargin(2);
     this.lx = lx;
+    this.ui = ui;
 
     audioMonitorLevels = audioMonitor;
     // When enabled, audio monitoring can trigger automatic channel switching.
@@ -197,22 +199,37 @@ public class UIModeSelector extends UICollapsibleSection {
     knobsContainer = new UI2dContainer(0, 30, getContentWidth(), 45);
     knobsContainer.setLayout(UI2dContainer.Layout.HORIZONTAL);
     knobsContainer.setPadding(0, 0, 0, 0);
+    fadeTime = new UIKnob(fadeTimeP);
+    fadeTime.addToContainer(knobsContainer);
+    knobsContainer.addToContainer(this);
+
+    UICollapsibleSection section;
+    section = new UICollapsibleSection(this.ui, 0, 0, getContentWidth(), 30);
+    section.setTitle("Standard Channel Timing");
+    section.setLayout(UI2dContainer.Layout.VERTICAL);
+    section.setChildMargin(2);
+    section.setBackgroundColor(0xFF222222);
+    section.addToContainer(this);
+
+    knobsContainer = new UI2dContainer(0, 30, getContentWidth(), 45);
+    knobsContainer.setLayout(UI2dContainer.Layout.HORIZONTAL);
+    knobsContainer.setPadding(0, 0, 0, 0);
     timePerChannel = new UIKnob(timePerChannelP);
     timePerChannel.addToContainer(knobsContainer);
     timePerChannel2 = new UIKnob(timePerChannelP2);
     timePerChannel2.addToContainer(knobsContainer);
     timePerChannel3 = new UIKnob(timePerChannelP3);
     timePerChannel3.addToContainer(knobsContainer);
-    knobsContainer.addToContainer(this);
-
-    knobsContainer = new UI2dContainer(0, 30, getContentWidth(), 45);
-    knobsContainer.setLayout(UI2dContainer.Layout.HORIZONTAL);
-    knobsContainer.setPadding(0, 0, 0, 0);
     timePerChannel4 = new UIKnob(timePerChannelP4);
     timePerChannel4.addToContainer(knobsContainer);
-    fadeTime = new UIKnob(fadeTimeP);
-    fadeTime.addToContainer(knobsContainer);
-    knobsContainer.addToContainer(this);
+    knobsContainer.addToContainer(section);
+
+    section = new UICollapsibleSection(this.ui, 0, 0, getContentWidth(), 30);
+    section.setTitle("Audio Channel Timing");
+    section.setLayout(UI2dContainer.Layout.VERTICAL);
+    section.setChildMargin(2);
+    section.setBackgroundColor(0xFF222222);
+    section.addToContainer(this);
 
     knobsContainer = new UI2dContainer(0, 30, getContentWidth(), 45);
     knobsContainer.setLayout(UI2dContainer.Layout.HORIZONTAL);
@@ -221,7 +238,7 @@ public class UIModeSelector extends UICollapsibleSection {
     timePerAudioChannel1.addToContainer(knobsContainer);
     timePerAudioChannel2 = new UIKnob(timePerAudioChannelP2);
     timePerAudioChannel2.addToContainer(knobsContainer);
-    knobsContainer.addToContainer(this);
+    knobsContainer.addToContainer(section);
 
     if (lx.engine.audio.input != null) {
       if (lx.engine.audio.input.device.getObject().isAvailable()) {


### PR DESCRIPTION
With this change, Audio mode now has two channels: `AUDIO-1` and `AUDIO-MULTI`.

`AUDIO-MULTI` is a group of an `AUDIO-FORM` and a multiplied `AUDIO-COLOR`, akin to the existing `MULTI` channel group.

The `UIModeSelector` UI now has two collapsible sections for channel timings, one for Standard and one for Audio.